### PR TITLE
Some reverse engineered special chars in SCC

### DIFF
--- a/Subtitle Files/src/subtitleFile/FormatSCC.java
+++ b/Subtitle Files/src/subtitleFile/FormatSCC.java
@@ -865,21 +865,21 @@ public class FormatSCC implements TimedTextFileFormat {
 		case 42:
 			return "�";
 		case 92:
-			return "�";
+			return "é";
 		case 94:
-			return "�";
+			return "í";
 		case 95:
-			return "�";
+			return "ó";
 		case 96:
-			return "�";
+			return "ú";
 		case 123:
-			return "�";
+			return "ç";
 		case 124:
 			return "�";
 		case 125:
-			return "�";
+			return "Ñ";
 		case 126:
-			return "�";
+			return "ñ";
 		case 127:
 			return "|";
 		case 0:


### PR DESCRIPTION
Some characters have been garbled up in translation between encodings (I
guess), have replaced those that I managed to translate back.

I'd be happy to clean up the other chars if you just send me a translation table or some URLs, all I was able to find was http://www.theneitherworld.com/mcpoodle/SCC_TOOLS/DOCS/SCC_FORMAT.HTML and its "translation matrix" which I did not manage to puzzle together to something usefull.
