### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>") to reduce the verbosity of generics code.

### DIFF
--- a/src/main/java/subtitleFile/FormatASS.java
+++ b/src/main/java/subtitleFile/FormatASS.java
@@ -207,7 +207,7 @@ public class FormatASS implements TimedTextFileFormat {
 		//we will write the lines in an ArrayList 
 		int index = 0;
 		//the minimum size of the file is the number of captions and styles + lines for sections and formats and the script info, so we'll take some extra space.
-		ArrayList<String> file = new ArrayList<String>(30+tto.styling.size()+tto.captions.size());
+		ArrayList<String> file = new ArrayList<>(30 + tto.styling.size() + tto.captions.size());
 
 	//header is placed
 		file.add(index++,"[Script Info]");

--- a/src/main/java/subtitleFile/FormatSCC.java
+++ b/src/main/java/subtitleFile/FormatSCC.java
@@ -377,7 +377,7 @@ public class FormatSCC implements TimedTextFileFormat {
 		//we will write the lines in an ArrayList 
 		int index = 0;
 		//the minimum size of the file is double the number of captions since lines are double spaced.
-		ArrayList<String> file = new ArrayList<String>(20 + 2*tto.captions.size());
+		ArrayList<String> file = new ArrayList<>(20 + 2 * tto.captions.size());
 
 		//first we add the header
 		file.add(index++,"Scenarist_SCC V1.0\n");

--- a/src/main/java/subtitleFile/FormatSRT.java
+++ b/src/main/java/subtitleFile/FormatSRT.java
@@ -140,7 +140,7 @@ public class FormatSRT implements TimedTextFileFormat {
 		//we will write the lines in an ArrayList,
 		int index = 0;
 		//the minimum size of the file is 4*number of captions, so we'll take some extra space.
-		ArrayList<String> file = new ArrayList<String>(5*tto.captions.size());
+		ArrayList<String> file = new ArrayList<>(5 * tto.captions.size());
 		//we iterate over our captions collection, they are ordered since they come from a TreeMap
 		Collection<Caption> c = tto.captions.values();
 		Iterator<Caption> itr = c.iterator();

--- a/src/main/java/subtitleFile/FormatTTML.java
+++ b/src/main/java/subtitleFile/FormatTTML.java
@@ -256,7 +256,7 @@ public class FormatTTML implements TimedTextFileFormat {
 		//we will write the lines in an ArrayList 
 		int index = 0;
 		//the minimum size of the file is the number of captions and styles + lines for sections and formats and the metadata, so we'll take some extra space.
-		ArrayList<String> file = new ArrayList<String>(30+tto.styling.size()+tto.captions.size());
+		ArrayList<String> file = new ArrayList<>(30 + tto.styling.size() + tto.captions.size());
 
 		//identification line is placed
 		file.add(index++,"<?xml version=\"1.0\" encoding=\"UTF-8\"?>");

--- a/src/main/java/subtitleFile/TimedTextObject.java
+++ b/src/main/java/subtitleFile/TimedTextObject.java
@@ -72,9 +72,9 @@ public class TimedTextObject {
 	 */
 	protected TimedTextObject(){
 		
-		styling = new Hashtable<String, Style>();
-		layout = new Hashtable<String, Region>();
-		captions = new TreeMap<Integer, Caption>(); 
+		styling = new Hashtable<>();
+		layout = new Hashtable<>();
+		captions = new TreeMap<>(); 
 		
 		warnings = "List of non fatal errors produced during parsing:\n\n";
 		
@@ -140,7 +140,7 @@ public class TimedTextObject {
 	 */
 	protected void cleanUnusedStyles(){
 		//here all used styles will be stored
-		Hashtable<String, Style> usedStyles = new Hashtable<String, Style>();
+		Hashtable<String, Style> usedStyles = new Hashtable<>();
 		//we iterate over the captions
 		Iterator<Caption> itrC = captions.values().iterator();
 		while(itrC.hasNext()){


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “The diamond operator ("<>") should be used ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.