### PR TITLE
Fixing code quality issues: squid:S2131 - squid:S1118

### DIFF
--- a/src/main/java/Convert.java
+++ b/src/main/java/Convert.java
@@ -16,6 +16,9 @@ import subtitleFile.TimedTextObject;
 
 public class Convert {
 
+	private Convert() {
+	}
+
 	/**
 	 * @param args
 	 */

--- a/src/main/java/IOClass.java
+++ b/src/main/java/IOClass.java
@@ -14,7 +14,10 @@ import java.io.PrintWriter;
  *
  */
 public class IOClass {
-	
+
+	private IOClass() {
+	}
+
 	/**
 	 * Method to get the file name (or path relative to the directory) and file to write to
 	 * in the form of an array of strings where each string represents a line

--- a/src/main/java/subtitleFile/FormatSCC.java
+++ b/src/main/java/subtitleFile/FormatSCC.java
@@ -886,7 +886,7 @@ public class FormatSCC implements TimedTextFileFormat {
 			//filler code
 			return "";
 		default:
-			return "" + (char)c;
+			return Character.toString((char)c);
 		}
 	}
 	

--- a/src/main/java/subtitleFile/FormatSRT.java
+++ b/src/main/java/subtitleFile/FormatSRT.java
@@ -150,7 +150,7 @@ public class FormatSRT implements TimedTextFileFormat {
 			//new caption
 			Caption current = itr.next();
 			//number is written
-			file.add(index++,""+captionNumber++);
+			file.add(index++, Integer.toString(captionNumber++));
 			//we check for offset value:
 			if(tto.offset != 0){
 				current.start.mseconds += tto.offset;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2131 - “Primitives should not be boxed just for "String" conversion”.
squid:S1118 - “Utility classes should not have public constructors ”.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2131
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.