### PR TITLE
Null pointers should not be dereferenced

### DIFF
--- a/src/main/java/subtitleFile/FormatSCC.java
+++ b/src/main/java/subtitleFile/FormatSCC.java
@@ -342,9 +342,11 @@ public class FormatSCC implements TimedTextFileFormat {
 					line = br.readLine();
 
 				}
-
-				//we save any last shown caption
-				newCaption.end =  new Time("h:m:s:f/fps", "99:59:59:29/29.97");;
+				
+				if(newCaption != null) {
+					//we save any last shown caption
+					newCaption.end = new Time("h:m:s:f/fps", "99:59:59:29/29.97");;
+				}
 				if (newCaption.start != null){
 					//we save the caption
 					int key = newCaption.start.mseconds;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2259 - “Null pointers should not be dereferenced”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2259
Please let me know if you have any questions.
Ayman Abdelghany.