### PR TITLE
Fix ASS parser misinterpreting subtitle text that contain commas in them.

### DIFF
--- a/src/main/java/subtitleFile/FormatASS.java
+++ b/src/main/java/subtitleFile/FormatASS.java
@@ -157,7 +157,7 @@ public class FormatASS implements TimedTextFileFormat {
 							//WARNING: all other events are ignored.
 							if (line.startsWith("Dialogue:")){
 								//we parse the dialogue
-								caption = parseDialogueForASS(line.split(":",2)[1].trim().split(",",10),dialogueFormat,timer, tto);
+								caption = parseDialogueForASS(line.split(":",2)[1].trim().split(",",dialogueFormat.length),dialogueFormat,timer, tto);
 								//and save the caption
 								int key = caption.start.mseconds;
 								//in case the key is already there, we increase it by a millisecond, since no duplicates are allowed


### PR DESCRIPTION
Some subtitle files contain text that have commas in them that are not escaped because they are the last entry in the `DialogueFormat`. An example of one file with this formatting is here: http://openings.moe/subtitles/Ending2-BokuWaTomodachiGaSukunai.ass

The parser originally would accept these files but this was broken in commit 7e01c9eea4a0ea24909033e94d691f58c777de55 to support other weirdly formatted subtitles. This PR fixes what I broke in that commit.