### PR TITLE
Add option to specify Charset when parsing a subtitle file

### DIFF
--- a/src/main/java/subtitleFile/FormatASS.java
+++ b/src/main/java/subtitleFile/FormatASS.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Iterator;
 
@@ -36,6 +37,10 @@ import java.util.Iterator;
 public class FormatASS implements TimedTextFileFormat {
 
 	public TimedTextObject parseFile(String fileName, InputStream is) throws IOException {
+		return parseFile(fileName, is, Charset.defaultCharset());
+	}
+
+	public TimedTextObject parseFile(String fileName, InputStream is, Charset isCharset) throws IOException {
 		
 		TimedTextObject tto = new TimedTextObject();
 		tto.fileName = fileName;
@@ -54,7 +59,7 @@ public class FormatASS implements TimedTextFileFormat {
 		String [] dialogueFormat;
 
 		//first lets load the file
-		InputStreamReader in= new InputStreamReader(is);
+		InputStreamReader in= new InputStreamReader(is, isCharset);
 		BufferedReader br = new BufferedReader(in);
 
 		String line;
@@ -312,7 +317,7 @@ public class FormatASS implements TimedTextFileFormat {
 			line+=",,0000,0000,0000,,";
 
 			//we add the caption text with \N as line breaks  and clean of XML
-			line +=  current.content.replaceAll("<br />","\\N").replaceAll("\\<.*?\\>", "");
+			line +=  current.content.replaceAll("<br />","\\\\N").replaceAll("\\<.*?\\>", "");
 			//and we add the caption line
 			file.add(index++,line);
 		}

--- a/src/main/java/subtitleFile/FormatSCC.java
+++ b/src/main/java/subtitleFile/FormatSCC.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Iterator;
 
@@ -35,6 +36,10 @@ import java.util.Iterator;
 public class FormatSCC implements TimedTextFileFormat {
 
 	public TimedTextObject parseFile(String fileName, InputStream is) throws IOException, FatalParsingException {
+		return parseFile(fileName, is, Charset.defaultCharset());
+	}
+
+	public TimedTextObject parseFile(String fileName, InputStream is, Charset isCharset) throws IOException, FatalParsingException {
 		
 		TimedTextObject tto = new TimedTextObject();
 		Caption newCaption = null;
@@ -50,7 +55,7 @@ public class FormatSCC implements TimedTextFileFormat {
 		String color = null;
 
 		//first lets load the file
-		BufferedReader br = new BufferedReader(new InputStreamReader(is));
+		BufferedReader br = new BufferedReader(new InputStreamReader(is, isCharset));
 
 		//the file name is saved
 		tto.fileName = fileName;

--- a/src/main/java/subtitleFile/FormatSRT.java
+++ b/src/main/java/subtitleFile/FormatSRT.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -38,6 +39,10 @@ public class FormatSRT implements TimedTextFileFormat {
 
 
 	public TimedTextObject parseFile(String fileName, InputStream is) throws IOException {
+		return parseFile(fileName, is, Charset.defaultCharset());
+	}
+
+	public TimedTextObject parseFile(String fileName, InputStream is, Charset isCharset) throws IOException {
 
 		TimedTextObject tto = new TimedTextObject();
 		Caption caption = new Caption();
@@ -45,7 +50,7 @@ public class FormatSRT implements TimedTextFileFormat {
 		boolean allGood;
 
 		//first lets load the file
-		InputStreamReader in= new InputStreamReader(is);
+		InputStreamReader in= new InputStreamReader(is, isCharset);
 		BufferedReader br = new BufferedReader(in);
 
 		//the file name is saved

--- a/src/main/java/subtitleFile/FormatSTL.java
+++ b/src/main/java/subtitleFile/FormatSTL.java
@@ -2,6 +2,7 @@ package subtitleFile;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -36,6 +37,10 @@ import java.util.Iterator;
 public class FormatSTL implements TimedTextFileFormat {
 
 	public TimedTextObject parseFile(String fileName, InputStream is) throws IOException, FatalParsingException {
+		return parseFile(fileName, is, Charset.defaultCharset());
+	}
+
+	public TimedTextObject parseFile(String fileName, InputStream is, Charset isCharset) throws IOException, FatalParsingException {
 
 		TimedTextObject tto = new TimedTextObject();
 		tto.fileName = fileName;

--- a/src/main/java/subtitleFile/FormatTTML.java
+++ b/src/main/java/subtitleFile/FormatTTML.java
@@ -2,6 +2,8 @@ package subtitleFile;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Iterator;
 
@@ -12,6 +14,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
 
 
 /**
@@ -43,6 +46,10 @@ public class FormatTTML implements TimedTextFileFormat {
 
 
 	public TimedTextObject parseFile(String fileName, InputStream is) throws IOException, FatalParsingException {
+		return parseFile(fileName, is, Charset.defaultCharset());
+	}
+
+	public TimedTextObject parseFile(String fileName, InputStream is, Charset isCharset) throws IOException, FatalParsingException {
 
 		TimedTextObject tto = new TimedTextObject();
 		tto.fileName = fileName;
@@ -51,7 +58,7 @@ public class FormatTTML implements TimedTextFileFormat {
 		DocumentBuilder dBuilder;
 		try {
 			dBuilder = dbFactory.newDocumentBuilder();
-			Document doc = dBuilder.parse(is);
+			Document doc = dBuilder.parse(new InputSource(new InputStreamReader(is, isCharset)));
 			doc.getDocumentElement().normalize();
 			
 			//we recover the metadata

--- a/src/main/java/subtitleFile/TimedTextFileFormat.java
+++ b/src/main/java/subtitleFile/TimedTextFileFormat.java
@@ -2,6 +2,7 @@ package subtitleFile;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 
 /**
  * This class specifies the interface for any format supported by the converter, these formats must
@@ -40,6 +41,15 @@ public interface TimedTextFileFormat {
 	 * @throws java.io.IOException when having trouble reading the file from the given path
 	 */
 	TimedTextObject parseFile(String fileName, InputStream is) throws IOException, FatalParsingException;
+
+	/**
+	 * This methods receives the path to a file, parses it, and returns a TimedTextObject
+	 * @param path String that contains the path to the file
+	 * @param isCharset the Charset to use when reading the InputStream
+	 * @return TimedTextObject representing the parsed file
+	 * @throws java.io.IOException when having trouble reading the file from the given path
+	 */
+	TimedTextObject parseFile(String fileName, InputStream is, Charset isCharset) throws IOException, FatalParsingException;
 	
 	/**
 	 * This method transforms a given TimedTextObject into a formated subtitle file


### PR DESCRIPTION
Currently there is no way to specify a Charset when passing the InputStream representing a subtitle file. This means the default encoding of the JVM is always used. If the default is not unicode but locale-specific, this library won't be able to parse a subtitle file that contains characters from another locale.

This PR add an option to specify the charset, e.g. UTF-8, of the InputStream representing a subtitle file.

Also fix issue #36
